### PR TITLE
Prune nodes which had at least one attempt, and it was not successfull

### DIFF
--- a/dnsseed.go
+++ b/dnsseed.go
@@ -61,7 +61,6 @@ func creep() {
 	var knownPeers []*appmessage.NetAddress
 
 	if len(ActiveConfig().KnownPeers) != 0 {
-
 		for _, p := range strings.Split(ActiveConfig().KnownPeers, ",") {
 			addressStr := strings.Split(p, ":")
 			if len(addressStr) != 2 {
@@ -138,8 +137,9 @@ func creep() {
 }
 
 func pollPeer(netAdapter *standalone.MinimalNetAdapter, addr *appmessage.NetAddress) error {
-	peerAddress := net.JoinHostPort(addr.IP.String(), strconv.Itoa(int(addr.Port)))
+	defer amgr.Attempt(addr.IP)
 
+	peerAddress := net.JoinHostPort(addr.IP.String(), strconv.Itoa(int(addr.Port)))
 	routes, err := netAdapter.Connect(peerAddress)
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to %s", peerAddress)
@@ -162,7 +162,6 @@ func pollPeer(netAdapter *standalone.MinimalNetAdapter, addr *appmessage.NetAddr
 	log.Infof("Peer %s sent %d addresses, %d new",
 		peerAddress, len(msgAddresses.AddressList), added)
 
-	amgr.Attempt(addr.IP)
 	amgr.Good(addr.IP, nil)
 
 	return nil

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/manager.go
+++ b/manager.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kaspanet/kaspad/infrastructure/network/addressmanager"
+
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/miekg/dns"
@@ -62,64 +64,6 @@ const (
 	pruneExpireTimeout = time.Hour * 8
 )
 
-var (
-	// rfc1918Nets specifies the IPv4 private address blocks as defined by
-	// by RFC1918 (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16).
-	rfc1918Nets = []net.IPNet{
-		ipNet("10.0.0.0", 8, 32),
-		ipNet("172.16.0.0", 12, 32),
-		ipNet("192.168.0.0", 16, 32),
-	}
-
-	// rfc3964Net specifies the IPv6 to IPv4 encapsulation address block as
-	// defined by RFC3964 (2002::/16).
-	rfc3964Net = ipNet("2002::", 16, 128)
-
-	// rfc4380Net specifies the IPv6 teredo tunneling over UDP address block
-	// as defined by RFC4380 (2001::/32).
-	rfc4380Net = ipNet("2001::", 32, 128)
-
-	// rfc4843Net specifies the IPv6 ORCHID address block as defined by
-	// RFC4843 (2001:10::/28).
-	rfc4843Net = ipNet("2001:10::", 28, 128)
-
-	// rfc4862Net specifies the IPv6 stateless address autoconfiguration
-	// address block as defined by RFC4862 (FE80::/64).
-	rfc4862Net = ipNet("FE80::", 64, 128)
-
-	// rfc4193Net specifies the IPv6 unique local address block as defined
-	// by RFC4193 (FC00::/7).
-	rfc4193Net = ipNet("FC00::", 7, 128)
-)
-
-// ipNet returns a net.IPNet struct given the passed IP address string, number
-// of one bits to include at the start of the mask, and the total number of bits
-// for the mask.
-func ipNet(ip string, ones, bits int) net.IPNet {
-	return net.IPNet{IP: net.ParseIP(ip), Mask: net.CIDRMask(ones, bits)}
-}
-
-func isRoutable(addr net.IP) bool {
-	if ActiveConfig().NetParams().AcceptUnroutable {
-		return true
-	}
-
-	for _, n := range rfc1918Nets {
-		if n.Contains(addr) {
-			return false
-		}
-	}
-	if rfc3964Net.Contains(addr) ||
-		rfc4380Net.Contains(addr) ||
-		rfc4843Net.Contains(addr) ||
-		rfc4862Net.Contains(addr) ||
-		rfc4193Net.Contains(addr) {
-		return false
-	}
-
-	return true
-}
-
 // NewManager constructs and returns a new dnsseeder manager, with the provided dataDir
 func NewManager(dataDir string) (*Manager, error) {
 	amgr := Manager{
@@ -152,7 +96,7 @@ func (m *Manager) AddAddresses(addrs []*appmessage.NetAddress) int {
 
 	m.mtx.Lock()
 	for _, addr := range addrs {
-		if !isRoutable(addr.IP) {
+		if !addressmanager.IsRoutable(addr, ActiveConfig().NetParams().AcceptUnroutable) {
 			continue
 		}
 		addrStr := addr.IP.String()
@@ -296,17 +240,24 @@ func (m *Manager) prunePeers() {
 	var count int
 	now := time.Now()
 	m.mtx.Lock()
+
+	lastSeenAbovePruneExpire := func(node *Node) bool {
+		return now.Sub(node.LastSeen) > pruneExpireTimeout
+	}
+	hadAttemptsButNoSuccess := func(node *Node) bool {
+		return !node.LastAttempt.IsZero() && node.LastSuccess.IsZero()
+	}
+	hadSuccessButLongTimeAgo := func(node *Node) bool {
+		return !node.LastSuccess.IsZero() && now.Sub(node.LastSuccess) > pruneExpireTimeout
+	}
+
 	for k, node := range m.nodes {
-		if now.Sub(node.LastSeen) > pruneExpireTimeout {
+		if lastSeenAbovePruneExpire(node) ||
+			hadAttemptsButNoSuccess(node) ||
+			hadSuccessButLongTimeAgo(node) {
+
 			delete(m.nodes, k)
 			count++
-			continue
-		}
-		if !node.LastSuccess.IsZero() &&
-			now.Sub(node.LastSuccess) > pruneExpireTimeout {
-			delete(m.nodes, k)
-			count++
-			continue
 		}
 	}
 	l := len(m.nodes)


### PR DESCRIPTION
The current situation is that if a node had 0 success, but was seen advertised recently - will never be pruned.

Since there are many dead nodes on the network, the chance for a node to be never advertised is close to nil, therefore it stays there for perpetuity.

This PR might make the pruning a bit too aggressive - a node that had one failed connection attempt will most probably be pruned.
However, I believe it's much better then the current situation, and anyway, the assumption is that a good listening node will be advertised by someone sometime, so it won't be lost for ever.