### PR TITLE
Logging improvements

### DIFF
--- a/config.go
+++ b/config.go
@@ -56,6 +56,7 @@ type ConfigFlags struct {
 	GRPCListen  string `long:"grpclisten" description:"Listen gRPC requests on address:port"`
 	NetSuffix   uint16 `long:"netsuffix" description:"Testnet network suffix number"`
 	NoLogFiles  bool   `long:"nologfiles" description:"Disable logging to file"`
+	LogLevel    string `long:"loglevel" description:"Loglevel for stdout (console). Default: Info"`
 	config.NetworkFlags
 }
 
@@ -205,7 +206,7 @@ func loadConfig() (*ConfigFlags, error) {
 		}
 	}
 
-	initLog(activeConfig.NoLogFiles, appLogFile, appErrLogFile)
+	initLog(activeConfig.NoLogFiles, activeConfig.LogLevel, appLogFile, appErrLogFile)
 
 	return activeConfig, nil
 }

--- a/config.go
+++ b/config.go
@@ -55,6 +55,7 @@ type ConfigFlags struct {
 	Profile     string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	GRPCListen  string `long:"grpclisten" description:"Listen gRPC requests on address:port"`
 	NetSuffix   uint16 `long:"netsuffix" description:"Testnet network suffix number"`
+	NoLogFiles  bool   `long:"nologfiles" description:"Disable logging to file"`
 	config.NetworkFlags
 }
 
@@ -204,7 +205,7 @@ func loadConfig() (*ConfigFlags, error) {
 		}
 	}
 
-	initLog(appLogFile, appErrLogFile)
+	initLog(activeConfig.NoLogFiles, appLogFile, appErrLogFile)
 
 	return activeConfig, nil
 }

--- a/dnsseed.go
+++ b/dnsseed.go
@@ -125,7 +125,7 @@ func creep() {
 
 				err := pollPeer(netAdapter, addr)
 				if err != nil {
-					log.Warnf(err.Error())
+					log.Debugf(err.Error())
 					if defaultSeeder != nil && addr == defaultSeeder {
 						panics.Exit(log, "failed to poll default seeder")
 					}

--- a/log.go
+++ b/log.go
@@ -14,22 +14,24 @@ var (
 	spawn      = panics.GoroutineWrapperFunc(log)
 )
 
-func initLog(logFile, errLogFile string) {
-	err := backendLog.AddLogFile(logFile, logger.LevelTrace)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", logFile, logger.LevelTrace, err)
-		os.Exit(1)
-	}
-	err = backendLog.AddLogFile(errLogFile, logger.LevelWarn)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", errLogFile, logger.LevelWarn, err)
-		os.Exit(1)
-	}
-
-	err = backendLog.AddLogWriter(os.Stdout, logger.LevelInfo)
+func initLog(noLogFiles bool, logFile, errLogFile string) {
+	err := backendLog.AddLogWriter(os.Stdout, logger.LevelInfo)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error adding stdout to the loggerfor level %s: %s", logger.LevelWarn, err)
 		os.Exit(1)
+	}
+
+	if !noLogFiles {
+		err = backendLog.AddLogFile(logFile, logger.LevelTrace)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", logFile, logger.LevelTrace, err)
+			os.Exit(1)
+		}
+		err = backendLog.AddLogFile(errLogFile, logger.LevelWarn)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", errLogFile, logger.LevelWarn, err)
+			os.Exit(1)
+		}
 	}
 
 	err = backendLog.Run()

--- a/log.go
+++ b/log.go
@@ -14,8 +14,9 @@ var (
 	spawn      = panics.GoroutineWrapperFunc(log)
 )
 
-func initLog(noLogFiles bool, logFile, errLogFile string) {
-	err := backendLog.AddLogWriter(os.Stdout, logger.LevelInfo)
+func initLog(noLogFiles bool, logLevel, logFile, errLogFile string) {
+	level, _ := logger.LevelFromString(logLevel)
+	err := backendLog.AddLogWriter(os.Stdout, level)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error adding stdout to the loggerfor level %s: %s", logger.LevelWarn, err)
 		os.Exit(1)

--- a/log.go
+++ b/log.go
@@ -15,10 +15,14 @@ var (
 )
 
 func initLog(noLogFiles bool, logLevel, logFile, errLogFile string) {
-	level, _ := logger.LevelFromString(logLevel)
+	level, ok := logger.LevelFromString(logLevel)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Invalid loglevel: %s", logLevel)
+		os.Exit(1)
+	}
 	err := backendLog.AddLogWriter(os.Stdout, level)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error adding stdout to the loggerfor level %s: %s", logger.LevelWarn, err)
+		fmt.Fprintf(os.Stderr, "Error adding stdout to the logger for level %s: %s", logger.LevelWarn, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
1. Two new command line flags, which are nice to have when running in a container env:
--nologfiles (disable logging to file entirely)
--loglevel (set loglevel for stdout / console. Default = INFO, as before)

2. Reduced severity of peer connection errors from WARN to DEBUG, to avoid cluttering the output with all the non-reachable nodes.