### PR TITLE
loglevel should default to info

### DIFF
--- a/config.go
+++ b/config.go
@@ -206,6 +206,9 @@ func loadConfig() (*ConfigFlags, error) {
 		}
 	}
 
+	if activeConfig.LogLevel == "" {
+		activeConfig.LogLevel = "Info"
+	}
 	initLog(activeConfig.NoLogFiles, activeConfig.LogLevel, appLogFile, appErrLogFile)
 
 	return activeConfig, nil


### PR DESCRIPTION
The changes in bd49ce3 effectively makes the loglevel argument mandatory, when it should default to INFO.