### PR TITLE
Fix wrong argument types in grpc_test.go

### DIFF
--- a/grpc_test.go
+++ b/grpc_test.go
@@ -36,7 +36,7 @@ func TestGetPeers(t *testing.T) {
 	ip := net.IP([]byte{203, 105, 20, 21})
 	netAddress := appmessage.NewNetAddressIPPort(ip, uint16(peersDefaultPort))
 	amgr.AddAddresses([]*appmessage.NetAddress{netAddress})
-	amgr.Good(ip, nil)
+	amgr.Good(netAddress, nil, nil)
 
 	host := "localhost:3737"
 	grpcServer := NewGRPCServer(amgr)


### PR DESCRIPTION
## Summary

In `grpc_test.go:39`, the test called `amgr.Good(ip, nil)` passing `net.IP` and `nil`, but the `Manager.Good()` method signature expects `(*appmessage.NetAddress, *string, *externalapi.DomainSubnetworkID)`.

```go
// current (broken)
amgr.Good(ip, nil)

// fixed
amgr.Good(netAddress, nil, nil)
```

The `netAddress` variable (type `*appmessage.NetAddress`) was already created on line 37 with `appmessage.NewNetAddressIPPort(ip, port)` — it was just never used in the `Good()` call.